### PR TITLE
Move PreferencesDataStore extension to separated module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+:warning: **Breaking change:** `PreferenceDataStoreFactory.createEncrypted` extension has been moved to separated module. To continue use it, change the dependency module in your build script:
+
+```diff
+-implmentation("io.github.osipxd:encrypted-datastore:...")
++implmentation("io.github.osipxd:encrypted-datastore-preferences:...")
+```
+
 ### Fixed
 
 - Fixed crash when DataStore can not be decrypted (#1)

--- a/encrypted-datastore-internal-visibility-hack/build.gradle.kts
+++ b/encrypted-datastore-internal-visibility-hack/build.gradle.kts
@@ -10,8 +10,3 @@ java {
 dependencies {
     implementation(libs.androidx.datastore.preferences)
 }
-
-repositories {
-    mavenCentral()
-    google()
-}

--- a/encrypted-datastore-preferences/build.gradle.kts
+++ b/encrypted-datastore-preferences/build.gradle.kts
@@ -1,0 +1,28 @@
+import com.redmadrobot.build.dsl.ossrh
+
+plugins {
+    id("com.redmadrobot.kotlin-library")
+    id("com.redmadrobot.publish")
+}
+
+description = "Extensions to encrypt DataStore Preferences using Tink"
+
+val hackProject = project(":encrypted-datastore-internal-visibility-hack")
+dependencies {
+    api(project(":encrypted-datastore"))
+    api(libs.androidx.datastore.preferences)
+
+    // It will be embedded into jar and shouldn't be added to pom.xml file
+    compileOnly(hackProject)
+}
+
+// Embed hack into the jar
+tasks.jar {
+    from(hackProject.sourceSets["main"].output)
+}
+
+publishing {
+    repositories {
+        ossrh { credentials(PasswordCredentials::class) }
+    }
+}

--- a/encrypted-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStore.kt
+++ b/encrypted-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStore.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import java.io.File
 
-@Suppress("unused")
+@Suppress("UnusedReceiverParameter")
 public fun PreferenceDataStoreFactory.createEncrypted(
     aead: Aead,
     corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,

--- a/encrypted-datastore/build.gradle.kts
+++ b/encrypted-datastore/build.gradle.kts
@@ -7,20 +7,10 @@ plugins {
 
 description = "Extensions to encrypt DataStore using Tink"
 
-val hackProject = project(":encrypted-datastore-internal-visibility-hack")
 dependencies {
     api(kotlin("stdlib", version = libs.versions.kotlin.get()))
     api(libs.androidx.datastore)
-    api(libs.androidx.datastore.preferences)
     api(libs.tink)
-
-    // It will be embedded into jar and shouldn't be added to pom.xml file
-    compileOnly(hackProject)
-}
-
-// Embed hack into the jar
-tasks.jar {
-    from(hackProject.sourceSets["main"].output)
 }
 
 publishing {

--- a/encrypted-datastore/build.gradle.kts
+++ b/encrypted-datastore/build.gradle.kts
@@ -18,10 +18,6 @@ dependencies {
     compileOnly(hackProject)
 }
 
-repositories {
-    google()
-}
-
 // Embed hack into the jar
 tasks.jar {
     from(hackProject.sourceSets["main"].output)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,14 @@
 rootProject.name = "encrypted-datastore"
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
+
 include(
     "encrypted-datastore",
     "encrypted-datastore-internal-visibility-hack",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,5 +11,6 @@ dependencyResolutionManagement {
 
 include(
     "encrypted-datastore",
+    "encrypted-datastore-preferences",
     "encrypted-datastore-internal-visibility-hack",
 )


### PR DESCRIPTION
**Breaking change:** `PreferenceDataStoreFactory.createEncrypted` extension has been moved to separated module. To continue use it, change the dependency module in your build script:

```diff
-implmentation("io.github.osipxd:encrypted-datastore:...")
+implmentation("io.github.osipxd:encrypted-datastore-preferences:...")
```