### PR TITLE
New library `security-crypto-datastore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 ## [Unreleased]
 
-:warning: **Breaking change:** `PreferenceDataStoreFactory.createEncrypted` extension has been moved to separated module. To continue use it, change the dependency module in your build script:
-
-```diff
--implmentation("io.github.osipxd:encrypted-datastore:...")
-+implmentation("io.github.osipxd:encrypted-datastore-preferences:...")
-```
-
 #### Streaming serializer
 
 Introduced new extension-function `Serializer.encrypted(StreamingAead)` to encrypt DataStore in streaming manneer.
@@ -39,6 +32,18 @@ val streamingAead = handle.getPrimitive(StreamingAead::class.java)
 > 1. **Migration** - add fallback for `StreamingAead` using function `StreamingAead.withDecryptionFallback(Aead)`
 > 2. **Do nothing** - continue to use `Aead`
 > 3. **Destructive migration** - specify `CorruptionHandler` to replace old content with something else
+
+#### New module `encrypted-datastore-preferences`
+
+:warning: **Breaking change:** 
+
+All stuff related to Preference DataStore was moved to `io.github.osipxd:encrypted-datastore-preferences`.
+To continue use it, change the dependency module in your build script:
+
+```diff
+-implmentation("io.github.osipxd:encrypted-datastore:...")
++implmentation("io.github.osipxd:encrypted-datastore-preferences:...")
+```
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,39 @@
 ## [Unreleased]
 
-#### Streaming serializer
+#### More high-level library `security-crypto-datastore`
 
-Introduced new extension-function `Serializer.encrypted(StreamingAead)` to encrypt DataStore in streaming manneer.
-Old extension-function with `Aead` is not planned to be removed yet, but for all new code it is recommended to use the new function.
-You can obtain `StreamingAead` similar to `Aead`:
+New library provides more simple and less error-prone API to create encrypted DataStores.
+All Tink-related stuff hidden from you in `security-crypto` library, and all you should do is wrap `File` with `EncryptedFile`:
 
 ```kotlin
-// Remember to initialize Tink
-//AeadConfig.register()
-StreamingAeadConfig.register()
-
-val handle = AndroidKeysetManager.Builder()
-    .withSharedPref(context, "master_keyset", "master_key_preference")
-    // Change key template AES256_GCM -> AES256_GCM_HKDF_4KB
-    //.withKeyTemplate(KeyTemplates.get("AES256_GCM"))
-    .withKeyTemplate(KeyTemplates.get("AES256_GCM_HKDF_4KB"))
-    .withMasterKeyUri("android-keystore://master_key")
-    .build()
-    .keysetHandle
-
-// Get StreamingAead instead of Aead
-//val aead = handle.getPrimitive(Aead::class.java)
-val streamingAead = handle.getPrimitive(StreamingAead::class.java)
+val dataStore = DataStoreFactory.createEncrypted(serializer) {
+    EncryptedFile.Builder(
+        context.dataStoreFile("filename"),
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
+}
 ```
+
+Or even simpler, if you use `security-crypto-ktx:1.1.0`:
+
+```kotlin
+val dataStore = DataStoreFactory.createEncrypted(serializer) {
+    EncryptedFile(
+        context = context,
+        file = context.dataStoreFile("filename"),
+        masterKey = MasterKey(context)
+    )
+}
+```
+
+See the [Migration guide](README.md#migration).
+
+#### Streaming serializer
+
+Introduced new extension-function `Serializer.encrypted(StreamingAead)` to encrypt DataStore in streaming manner.
+Old extension-function with `Aead` is not planned to be removed yet, but for all new code it is recommended to use the new function or migrate to the `security-crypto-datastore`.
 
 > **ATTENTION!**
 > You can not use `StreamingAead` to decrypt data encrypted with `Aead`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.0.0-alpha03] - 2022.11.18
+
 #### More high-level library `security-crypto-datastore`
 
 New library provides more simple and less error-prone API to create encrypted DataStores.
@@ -70,4 +72,5 @@ To continue use it, change the dependency module in your build script:
 - gradle-infrastructure `0.12.1` → `0.17`
 - Migrate dependencies to version catalogs
 
-[unreleased]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0-alpha02...main
+[unreleased]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0-alpha03...main
+[v1.0.0-alpha03]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0-alpha02...v1.0.0-alpha03

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# encrypted-datastore
+# Encrypted DataStore
 [![Version](https://img.shields.io/maven-central/v/io.github.osipxd/encrypted-datastore?style=flat-square)][mavenCentral] [![License](https://img.shields.io/github/license/osipxd/encrypted-datastore?style=flat-square)][license]
 
-Extensions to encrypt DataStore using [Tink].
+Extensions to store DataStore in `EncryptedFile`.
 
-> :warning: This tiny library will be maintained until an official solution for DataStore encryption will be released by Google.
+> :warning: This tiny library will be maintained until an official solution for DataStore encryption will be released by Google. \
+> Vote for this feature on issue tracker: [b/167697691](https://issuetracker.google.com/issues/167697691)
 
 ---
 
@@ -18,15 +19,93 @@ repositories {
 }
 
 dependencies {
-    implementation("io.github.osipxd:encrypted-datastore:1.0.0-alpha02")
+    implementation("io.github.osipxd:security-crypto-datastore:1.0.0-alpha03")
+    // Or, if you want to use Preferences DataStore:
+    implementation("io.github.osipxd:security-crypto-datastore-preferences:1.0.0-alpha03")
 }
 ```
 
+> **Dependencies:**
+> - `security-crypto` [1.0.0](https://developer.android.com/jetpack/androidx/releases/security#1.0.0)
+> - `datastore` [1.0.0](https://developer.android.com/jetpack/androidx/releases/datastore#1.0.0)
+> - `tink` [1.7.0](https://github.com/google/tink/releases/tag/v1.7.0)
+
 ## Usage
 
-First, you need to create `Aead` object to encrypt DataStore or you may use already created one:
+To create encrypted DataStore, just use method `DataStoreFactory.createEncryptred` instead of `create` and
+provide `EncryptedFile` instead of `File`:
 
 ```kotlin
+val dataStore = DataStoreFactory.createEncrypted(serializer) {
+    EncryptedFile.Builder(
+        context.dataStoreFile("filename"),
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
+}
+```
+
+<details>
+<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>
+
+```kotlin
+val dataStore = DataStoreFactory.createEncrypted(serializer) {
+    EncryptedFile(
+        context = context,
+        file = context.dataStoreFile("filename"),
+        masterKey = MasterKey(context)
+    )
+}
+```
+</details>
+
+Similarly, you can create Preferences DataStore:
+
+```kotlin
+val dataStore = DataStoreFactory.createEncrypted(serializer) {
+    EncryptedFile.Builder(
+        // The file should have extension .preferences_pb
+        context.dataStoreFile("filename.preferences_pb"),
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
+}
+```
+
+<details>
+<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>
+
+```kotlin
+val dataStore = PreferenceDataStoreFactory.createEncrypted {
+    EncryptedFile(
+        context = context,
+        // The file should have extension .preferences_pb
+        file = context.dataStoreFile("filename.preferences_pb"),
+        masterKey = MasterKey(context)
+    )
+}
+```
+</details>
+
+## Migration
+
+### Migrate from `encrypted-datastore` to `security-crypto-datastore`
+
+Change the dependency in build script:
+
+```diff
+ dependencies {
+-    implementation("io.github.osipxd:encrypted-datastore:...")
++    implementation("io.github.osipxd:security-crypto-datastore:...")
+ }
+```
+
+New library uses `StreamingAead` instead of `Aead` under the hood, so to not lose the previously encrypted data you should specify `fallbackAead`:
+
+```kotlin
+// This AEAD was used to encrypt DataStore previously, we will use it as fallback
 val aead = AndroidKeysetManager.Builder()
     .withSharedPref(context, "master_keyset", "master_key_preference")
     .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
@@ -36,25 +115,47 @@ val aead = AndroidKeysetManager.Builder()
     .getPrimitive(Aead::class.java)
 ```
 
-Then you can make any DataStore Serializer encrypted using extension-function `Serializer<T>.encrypted(Aead)`:
-
+The old code to create DataStore was looking like this:
 ```kotlin
-object ProtoProfileSerializer : Serializer<Profile> {
-    // serializer implementation here
-}
-
-val dataStore = DataStoreFactory.create(ProtoProfileSerializer.encrypted(aead)) {
-    context.dataStoreFile("proto_profile")
+val dataStore = DataStoreFactory.create(serializer.encrypted(aead)) {
+    context.dataStoreFile("filename")
 }
 ```
 
-If you need to create encrypted `PreferenceDataStore`, use function `createEncrypted` instead of `create`:
-
+The new code will look like this:
 ```kotlin
-val prefsDataStore = PreferenceDataStoreFactory.createEncrypted(aead) {
-    context.preferencesDataStoreFile("user_preferences")
+val dataStore = DataStoreFactory.createEncrypted(
+    serializer,
+    encryptionOptions = {
+        // Specify fallback Aead to make it possible to decrypt data encrypted with it
+        fallbackAead = aead
+    }
+) {
+    EncryptedFile.Builder(
+        context.dataStoreFile("filename"), // Keep the same file
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
 }
 ```
+
+<details>
+<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>
+
+```kotlin
+val dataStore = DataStoreFactory.createEncrypted(
+    serializer,
+    encryptionOptions = { fallbackAead = aead }
+) {
+    EncryptedFile(
+        context = context,
+        file = context.dataStoreFile("filename"), // Keep the same file
+        masterKey = MasterKey(context)
+    )
+}
+```
+</details>
 
 ### Thanks
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 val datastoreVersion = libs.versions.datastore.get()
 subprojects {
     group = "io.github.osipxd"
-    version = "$datastoreVersion-alpha02"
+    version = "$datastoreVersion-alpha03"
 }
 
 redmadrobot {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,16 @@ import com.redmadrobot.build.dsl.*
 
 plugins {
     com.redmadrobot.`publish-config`
+    com.redmadrobot.`android-config`
 }
 
 group = "io.github.osipxd"
 version = "${libs.versions.datastore.get()}-alpha02"
 
 redmadrobot {
+    // Min SDK should be aligned with min SDK in androidx.security:security-crypto
+    android.minSdk.set(21)
+
     publishing {
         signArtifacts.set(true)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,17 @@
-import com.redmadrobot.build.dsl.*
+import com.redmadrobot.build.dsl.developer
+import com.redmadrobot.build.dsl.mit
+import com.redmadrobot.build.dsl.setGitHubProject
 
 plugins {
     com.redmadrobot.`publish-config`
     com.redmadrobot.`android-config`
 }
 
-group = "io.github.osipxd"
-version = "${libs.versions.datastore.get()}-alpha02"
+val datastoreVersion = libs.versions.datastore.get()
+subprojects {
+    group = "io.github.osipxd"
+    version = "$datastoreVersion-alpha02"
+}
 
 redmadrobot {
     // Min SDK should be aligned with min SDK in androidx.security:security-crypto

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,10 +3,13 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.infrastructure.android)
     implementation(libs.infrastructure.kotlin)
     implementation(libs.infrastructure.publish)
 }
 
 repositories {
     mavenCentral()
+    google()
+    gradlePluginPortal()
 }

--- a/buildSrc/src/main/kotlin/convention.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.publish.gradle.kts
@@ -1,7 +1,6 @@
 import com.redmadrobot.build.dsl.ossrh
 
 plugins {
-    id("com.redmadrobot.kotlin-library")
     id("com.redmadrobot.publish")
 }
 

--- a/config/lint/lint-baseline.xml
+++ b/config/lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.2.1" type="baseline" client="gradle" dependencies="true" name="AGP (7.2.1)" variant="all" version="7.2.1">
+
+</issues>

--- a/encrypted-datastore-internal-visibility-hack/build.gradle.kts
+++ b/encrypted-datastore-internal-visibility-hack/build.gradle.kts
@@ -8,5 +8,5 @@ java {
 }
 
 dependencies {
-    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore.preferences.core)
 }

--- a/encrypted-datastore-preferences/build.gradle.kts
+++ b/encrypted-datastore-preferences/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    convention.library
+    com.redmadrobot.`kotlin-library`
+    convention.publish
 }
 
 description = "Extensions to encrypt DataStore Preferences using Tink"

--- a/encrypted-datastore-preferences/build.gradle.kts
+++ b/encrypted-datastore-preferences/build.gradle.kts
@@ -8,7 +8,7 @@ description = "Extensions to encrypt DataStore Preferences using Tink"
 val hackProject = project(":encrypted-datastore-internal-visibility-hack")
 dependencies {
     api(project(":encrypted-datastore"))
-    api(libs.androidx.datastore.preferences)
+    api(libs.androidx.datastore.preferences.core)
 
     // It will be embedded into jar and shouldn't be added to pom.xml file
     compileOnly(hackProject)

--- a/encrypted-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStore.kt
+++ b/encrypted-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStore.kt
@@ -19,13 +19,9 @@ import java.io.File
 /**
  * Creates preference DataStore encrypted using the given [aead].
  *
- * **Deprecated** in favor of version with [StreamingAead].
- * You can not use to decrypt data encrypted with `Aead`,
- * so you can not just replace `Aead` with `StreamingAead` without migration.
- * To not lose your previously encrypted data, you have three options:
- *  1. **Migration** - add fallback for `StreamingAead` using function [StreamingAead.withDecryptionFallback]
- *  2. **Do nothing** - continue to use this method `Aead`
- *  3. **Destructive migration** - specify [ReplaceFileCorruptionHandler] to replace old content with something else
+ * **Deprecated.**
+ * It is recommended to migrate to `security-crypto-datastore` library:
+ * [Migration guide](https://github.com/osipxd/encrypted-datastore#migration)
  */
 @Deprecated("Use version of this method with StreamingAead instead of Aead")
 @Suppress("UnusedReceiverParameter")

--- a/encrypted-datastore/build.gradle.kts
+++ b/encrypted-datastore/build.gradle.kts
@@ -7,7 +7,7 @@ description = "Extensions to encrypt DataStore using Tink"
 
 dependencies {
     api(kotlin("stdlib", version = libs.versions.kotlin.get()))
-    api(libs.androidx.datastore)
+    api(libs.androidx.datastore.core)
     api(libs.tink)
 
     testImplementation(kotlin("test", version = libs.versions.kotlin.get()))

--- a/encrypted-datastore/build.gradle.kts
+++ b/encrypted-datastore/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    convention.library
+    com.redmadrobot.`kotlin-library`
+    convention.publish
 }
 
 description = "Extensions to encrypt DataStore using Tink"

--- a/encrypted-datastore/src/main/kotlin/EncryptingSerializer.kt
+++ b/encrypted-datastore/src/main/kotlin/EncryptingSerializer.kt
@@ -58,7 +58,10 @@ internal class AeadEncryptingSerializer<T>(
  * Adds encryption to [this] serializer using the given [Aead].
  *
  * **Deprecated** in favor of version with [StreamingAead].
- * You can not use to decrypt data encrypted with `Aead`,
+ * Consider to migrate to `security-crypto-datastore` library:
+ * [Migration guide](https://github.com/osipxd/encrypted-datastore#migration).
+ *
+ * You can not use `StreamingAead` to decrypt data encrypted with `Aead`,
  * so you can not just replace `Aead` with `StreamingAead` without migration.
  * To not lose your previously encrypted data, you have three options:
  *  1. **Migration** - add fallback for `StreamingAead` using function [StreamingAead.withDecryptionFallback]
@@ -94,7 +97,7 @@ internal class StreamingAeadEncryptingSerializer<T>(
             CorruptionException(
                 "Can not decrypt DataStore using StreamingAead.\n" +
                         "Probably you should add decryption fallback to Aead:\n" +
-                        "https://github.com/osipxd/encrypted-datastore#migration-to-streamingaead",
+                        "https://github.com/osipxd/encrypted-datastore#migration",
                 cause = this,
             )
         } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,37 @@
-android.useAndroidX = true
+## Gradle
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xmx1036m -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in parallel mode.
+# Parallel builds require projects to be decoupled at execution time, i.e.
+# tasks in different projects must not modify shared state.
+# https://docs.gradle.org/current/userguide/performance.html#parallel_execution
+org.gradle.parallel=true
+
+# Gradle will try to reuse outputs from previous builds for all builds, unless
+# explicitly disabled with --no-build-cache.
+# https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching=true
+
+## Android
+
+# Notify Android Gradle Plugin that we use AndroidX and not use Jetifier
+android.useAndroidX=true
+android.enableJetifier=false
+
+# Allow to open this project using IntelliJ IDEA or old version of Android Studio
+#android.injected.studio.version.check=false
+
+# Experimental support for using relative path sensitivity with CompileLibraryResourcesTask inputs
+# which will provide more build cache hits and improve build speed.
+android.experimental.cacheCompileLibResources=true
+android.experimental.enableSourceSetPathsMap=true
+
+
+## Kotlin
+
+# Use official kotlin code style
+kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,10 @@ infrastructure = "0.17"
 
 [libraries]
 
-androidx-datastore = { module = "androidx.datastore:datastore-core", version.ref = "datastore" }
-androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastore" }
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
+androidx-datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastore" }
 tink = "com.google.crypto.tink:tink-android:1.7.0"
 
 infrastructure-kotlin = { module = "com.redmadrobot.build:infrastructure-kotlin", version.ref = "infrastructure" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,9 @@ androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "d
 androidx-datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "datastore" }
+androidx-security-crypto = "androidx.security:security-crypto:1.0.0"
 tink = "com.google.crypto.tink:tink-android:1.7.0"
 
+infrastructure-android = { module = "com.redmadrobot.build:infrastructure-android", version.ref = "infrastructure" }
 infrastructure-kotlin = { module = "com.redmadrobot.build:infrastructure-kotlin", version.ref = "infrastructure" }
 infrastructure-publish = { module = "com.redmadrobot.build:infrastructure-publish", version.ref = "infrastructure" }

--- a/security-crypto-datastore-preferences/build.gradle.kts
+++ b/security-crypto-datastore-preferences/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    com.redmadrobot.`android-library`
+    convention.publish
+}
+
+description = "AndroidX Security Kotlin Extensions (with DataStore support)"
+
+android {
+    namespace = "$group.security.datastore.preferences"
+}
+
+dependencies {
+    implementation(project(":encrypted-datastore-preferences"))
+    api(project(":security-crypto-datastore"))
+    api(libs.androidx.datastore.preferences)
+}

--- a/security-crypto-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStoreFactory.kt
+++ b/security-crypto-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStoreFactory.kt
@@ -1,0 +1,69 @@
+@file:Suppress("UnusedReceiverParameter")
+
+package io.github.osipxd.security.crypto
+
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.security.crypto.EncryptedFile
+import io.github.osipxd.datastore.encrypted.PreferenceDataStore
+import io.github.osipxd.datastore.encrypted.PreferencesSerializer
+import io.github.osipxd.datastore.encrypted.checkPreferenceDataStoreFileExtension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Creates Preferences DataStore instance stored in [EncryptedFile].
+ * The file must have the extension "preferences_pb".
+ *
+ * Basic usage:
+ * ```
+ * val dataStore = PreferenceDataStoreFactory.createEncrypted {
+ *     EncryptedFile.Builder(
+ *          context.dataStoreFile("filename.preferences_pb"),
+ *          context,
+ *          MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+ *          EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+ *     ).build()
+ * }
+ * ```
+ *
+ * Or even simpler, if you use `security-crypto-ktx:1.1.0`:
+ * ```
+ * val dataStore = PreferenceDataStoreFactory.createEncrypted {
+ *     EncryptedFile(
+ *         context = context,
+ *         file = context.dataStoreFile("filename.preferences_pb"),
+ *         masterKey = MasterKey(context)
+ *     )
+ * }
+ * ```
+ *
+ * @see PreferenceDataStoreFactory.create
+ */
+public fun PreferenceDataStoreFactory.createEncrypted(
+    corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
+    migrations: List<DataMigration<Preferences>> = listOf(),
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    encryptionOptions: EncryptedDataStoreOptions.() -> Unit,
+    produceFile: () -> EncryptedFile,
+): DataStore<Preferences> {
+    val delegate = DataStoreFactory.createEncrypted(
+        serializer = PreferencesSerializer,
+        corruptionHandler = corruptionHandler,
+        migrations = migrations,
+        scope = scope,
+        encryptionOptions = encryptionOptions,
+        produceFile = produceFile()::checkPreferenceDataStoreFileExtension,
+    )
+
+    return PreferenceDataStore(delegate)
+}
+
+private fun EncryptedFile.checkPreferenceDataStoreFileExtension(): EncryptedFile = apply {
+    file.checkPreferenceDataStoreFileExtension()
+}

--- a/security-crypto-datastore/build.gradle.kts
+++ b/security-crypto-datastore/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    com.redmadrobot.`android-library`
+    convention.publish
+}
+
+description = "AndroidX Security Kotlin Extensions (with DataStore support)"
+
+android {
+    namespace = "$group.security.datastore"
+}
+
+dependencies {
+    implementation(project(":encrypted-datastore"))
+    api(libs.androidx.datastore)
+    api(libs.androidx.security.crypto)
+}

--- a/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreFactory.kt
+++ b/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreFactory.kt
@@ -1,0 +1,75 @@
+@file:Suppress("UnusedReceiverParameter")
+
+package io.github.osipxd.security.crypto
+
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Serializer
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.file
+import androidx.security.crypto.streamingAead
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.StreamingAead
+import io.github.osipxd.datastore.encrypted.encrypted
+import io.github.osipxd.datastore.encrypted.migration.withDecryptionFallback
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Creates DataStore instance stored in [EncryptedFile].
+ *
+ * Basic usage:
+ * ```
+ * val dataStore = DataStoreFactory.createEncrypted(serializer) {
+ *     EncryptedFile.Builder(
+ *          context.dataStoreFile("filename"),
+ *          context,
+ *          MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+ *          EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+ *     ).build()
+ * }
+ * ```
+ *
+ * Or even simpler, if you use `security-crypto-ktx:1.1.0`:
+ * ```
+ * val dataStore = DataStoreFactory.createEncrypted(serializer) {
+ *     EncryptedFile(
+ *         context = context,
+ *         file = context.dataStoreFile("filename"),
+ *         masterKey = MasterKey(context)
+ *     )
+ * }
+ * ```
+ *
+ * @see DataStoreFactory.create
+ */
+public fun <T> DataStoreFactory.createEncrypted(
+    serializer: Serializer<T>,
+    corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
+    migrations: List<DataMigration<T>> = listOf(),
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    encryptionOptions: EncryptedDataStoreOptions.() -> Unit = {},
+    produceFile: () -> EncryptedFile
+): DataStore<T> {
+    val options = EncryptedDataStoreOptions().also(encryptionOptions)
+    val encryptedFile = produceFile()
+
+    val streamingAead = encryptedFile.streamingAead.withDecryptionFallback(options.fallbackAead)
+    val file = encryptedFile.file
+    val associatedData = options.associatedData ?: file.name.toByteArray()
+
+    return create(
+        serializer = serializer.encrypted(streamingAead, associatedData),
+        corruptionHandler = corruptionHandler,
+        migrations = migrations,
+        scope = scope,
+        produceFile = { file },
+    )
+}
+
+private fun StreamingAead.withDecryptionFallback(fallbackAead: Aead?): StreamingAead {
+    return if (fallbackAead != null) this.withDecryptionFallback(fallbackAead) else this
+}

--- a/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreOptions.kt
+++ b/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreOptions.kt
@@ -1,0 +1,13 @@
+package io.github.osipxd.security.crypto
+
+import com.google.crypto.tink.Aead
+
+/** A class holding DataStore encryption options. */
+public class EncryptedDataStoreOptions internal constructor() {
+
+    /** The associated data. By default, will be used data store file name. */
+    public var associatedData: ByteArray? = null
+
+    /** The fallback [Aead]. You should provide it only if te datastore was previously encrypted with [Aead]. */
+    public var fallbackAead: Aead? = null
+}

--- a/security-crypto-datastore/src/main/kotlin/EncryptedFile.kt
+++ b/security-crypto-datastore/src/main/kotlin/EncryptedFile.kt
@@ -1,0 +1,9 @@
+package io.github.osipxd.security.crypto
+
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.file
+import java.io.File
+
+/** Exposes the underlying file. */
+public val EncryptedFile.file: File
+    get() = file

--- a/security-crypto-datastore/src/main/kotlin/internal/EncryptedFileVisibilityHack.kt
+++ b/security-crypto-datastore/src/main/kotlin/internal/EncryptedFileVisibilityHack.kt
@@ -1,0 +1,10 @@
+// We use fake package to hack package-private visibility
+@file:Suppress("PackageDirectoryMismatch")
+
+package androidx.security.crypto
+
+import com.google.crypto.tink.StreamingAead
+import java.io.File
+
+internal val EncryptedFile.file: File get() = mFile
+internal val EncryptedFile.streamingAead: StreamingAead get() = mStreamingAead

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,4 +13,5 @@ include(
     "encrypted-datastore",
     "encrypted-datastore-preferences",
     "encrypted-datastore-internal-visibility-hack",
+    "security-crypto-datastore",
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,4 +14,5 @@ include(
     "encrypted-datastore-preferences",
     "encrypted-datastore-internal-visibility-hack",
     "security-crypto-datastore",
+    "security-crypto-datastore-preferences",
 )


### PR DESCRIPTION
New library provides more simple and less error-prone API to create encrypted DataStores.
All Tink-related stuff hidden from you in `security-crypto` library, and all you should do is wrap `File` with `EncryptedFile`:

```kotlin
val dataStore = DataStoreFactory.createEncrypted(serializer) {
    EncryptedFile.Builder(
        context.dataStoreFile("filename"),
        context,
        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
    ).build()
}
```

<details>
<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>

```kotlin
val dataStore = DataStoreFactory.createEncrypted(serializer) {
    EncryptedFile(
        context = context,
        file = context.dataStoreFile("filename"),
        masterKey = MasterKey(context)
    )
}
```
</details>

Closes #7 