### PR TITLE
Add delegates for DataStore creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## [Unreleased]
 
+### Delegates to create encrypted DataStores
+
+Delegates `encryptedDataStore` and `encryptedPreferencesDataStore` were added to simplify DataStore creation.
+If you have the following code:
+
+```kotlin
+val dataStore = DataStoreFactory.createEncrypted(serializer) {
+    EncryptedFile.Builder(
+        context.dataStoreFile("filename"),
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
+}
+```
+
+You can simplify it using delegate for DataStore creation.
+
+```kotlin
+// 1. Move the field to top level of you Kotlin file and turn it to an extension on Context
+// 2. Replace `DataStoreFactory.createEncrypted` with `encryptedDataStore`
+val Context.dataStore by encryptedDataStore(
+    fileName = "filename", // Keep file the same
+    serializer = serializer,
+)
+```
+
+> [!NOTE]
+> This only will be interchangeable if you used `context.dataStoreFile(...)` to create datastore file.
+> In case you have custom logic for master key creation, pass the created master key as a parameter `masterKey` to the delegate.
+
 ### Dependencies
 
 - Target JVM `1.8` → `11`

--- a/README.md
+++ b/README.md
@@ -32,8 +32,60 @@ dependencies {
 
 ## Usage
 
-To create encrypted DataStore, just use method `DataStoreFactory.createEncryptred` instead of `create` and
-provide `EncryptedFile` instead of `File`:
+To create encrypted DataStore, just use method `encryptedDataStore` instead of `dataStore` to create delegate:
+
+```kotlin
+// At the top level of your Kotlin file:
+val Context.settingsDataStore: DataStore<Settings> by encryptedDataStore(
+    fileName = "settings.pb",
+    serializer = SettingsSerializer
+)
+```
+
+<details>
+<summary>Or, if you want full control over <code>EncryptedFile</code> creation</summary>
+
+```kotlin
+val settingsDataStore: DataStore<Settings> = DataStoreFactory.createEncrypted(SettingsSerializer) {
+    EncryptedFile.Builder(
+        context.dataStoreFile("settings.pb"),
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
+}
+```
+</details>
+
+Similarly, you can create Preferences DataStore:
+
+```kotlin
+// At the top level of your Kotlin file:
+val Context.dataStore by encryptedPreferencesDataStore(name = "settings")
+```
+
+<details>
+<summary>Or, if you want full control over <code>EncryptedFile</code> creation</summary>
+
+```kotlin
+val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createEncrypted {
+    EncryptedFile.Builder(
+        context.preferencesDataStoreFile("settings"),
+        context,
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+    ).build()
+}
+```
+</details>
+
+Then you can use the created encrypted DataStore just like simple DataDtore. Look at [the DataStore docs](https://developer.android.com/topic/libraries/architecture/datastore) for usage guide and examples.
+
+## Migration
+
+### Migrate from factory to delegate
+
+If you have the following code:
 
 ```kotlin
 val dataStore = DataStoreFactory.createEncrypted(serializer) {
@@ -46,56 +98,20 @@ val dataStore = DataStoreFactory.createEncrypted(serializer) {
 }
 ```
 
-<details>
-<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>
-
-> :warning: `security-crypto-ktx 1.1.0` is in alpha at the moment this library released, so use it at your own risk
+You can simplify it using delegate for DataStore creation.
 
 ```kotlin
-val dataStore = DataStoreFactory.createEncrypted(serializer) {
-    EncryptedFile(
-        context = context,
-        file = context.dataStoreFile("filename"),
-        masterKey = MasterKey(context)
-    )
-}
-```
-</details>
-
-Similarly, you can create Preferences DataStore:
-
-```kotlin
-val dataStore = PreferenceDataStoreFactory.createEncrypted {
-    EncryptedFile.Builder(
-        // The file should have extension .preferences_pb
-        context.dataStoreFile("filename.preferences_pb"),
-        context,
-        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
-    ).build()
-}
+// 1. Move the field to top level of you Kotlin file and turn it to an extension on Context
+// 2. Replace `DataStoreFactory.createEncrypted` with `encryptedDataStore`
+val Context.dataStore by encryptedDataStore(
+    fileName = "filename", // Keep file the same
+    serializer = serializer,
+)
 ```
 
-<details>
-<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>
-
-> :warning: `security-crypto-ktx 1.1.0` is in alpha at the moment this library released, so use it at your own risk
-
-```kotlin
-val dataStore = PreferenceDataStoreFactory.createEncrypted {
-    EncryptedFile(
-        context = context,
-        // The file should have extension .preferences_pb
-        file = context.dataStoreFile("filename.preferences_pb"),
-        masterKey = MasterKey(context)
-    )
-}
-```
-</details>
-
-Then you can use the created encrypted DataStore just like simple DataDtore. Look at [the DataStore docs](https://developer.android.com/topic/libraries/architecture/datastore) for usage guide and examples.
-
-## Migration
+> [!NOTE]
+> This only will be interchangeable if you used `context.dataStoreFile(...)` to create datastore file.
+> In case you have custom logic for master key creation, pass the created master key as a parameter `masterKey` to the delegate.
 
 ### Migrate from `encrypted-datastore` to `security-crypto-datastore`
 
@@ -122,6 +138,7 @@ val aead = AndroidKeysetManager.Builder()
 ```
 
 The old code to create DataStore was looking like this:
+
 ```kotlin
 val dataStore = DataStoreFactory.create(serializer.encrypted(aead)) {
     context.dataStoreFile("filename")
@@ -129,38 +146,33 @@ val dataStore = DataStoreFactory.create(serializer.encrypted(aead)) {
 ```
 
 The new code will look like this:
+
 ```kotlin
-val dataStore = DataStoreFactory.createEncrypted(
-    serializer,
+// At the top level of your Kotlin file:
+val Context.dataStore by encryptedDataStore(
+    fileName = "filename", // Keep file the same
+    serializer = serializer,
     encryptionOptions = {
         // Specify fallback Aead to make it possible to decrypt data encrypted with it
         fallbackAead = aead
     }
+)
+```
+
+<details>
+<summary>Or, if you want full control over <code>EncryptedFile</code> creation</summary>
+
+```kotlin
+val dataStore = DataStoreFactory.createEncrypted(
+    serializer = serializer,
+    encryptionOptions = { fallbackAead = aead }
 ) {
     EncryptedFile.Builder(
-        context.dataStoreFile("filename"), // Keep the same file
+        context.dataStoreFile("filename"), // Keep file the same
         context,
         MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
         EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
     ).build()
-}
-```
-
-<details>
-<summary>Or even simpler, if you use <code>security-crypto-ktx:1.1.0</code></summary>
-
-> :warning: `security-crypto-ktx 1.1.0` is in alpha at the moment this library released, so use it at your own risk
-
-```kotlin
-val dataStore = DataStoreFactory.createEncrypted(
-    serializer,
-    encryptionOptions = { fallbackAead = aead }
-) {
-    EncryptedFile(
-        context = context,
-        file = context.dataStoreFile("filename"), // Keep the same file
-        masterKey = MasterKey(context)
-    )
 }
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 Extensions to store DataStore in `EncryptedFile`.
 
-> :warning: This tiny library will be maintained until an official solution for DataStore encryption will be released by Google. \
+> [!WARNING]
+> This tiny library will be maintained until an official solution for DataStore encryption will be released by Google.
 > Vote for this feature on issue tracker: [b/167697691](https://issuetracker.google.com/issues/167697691)
 
 ---
@@ -28,7 +29,7 @@ dependencies {
 > **Dependencies:**
 > - `security-crypto` [1.0.0](https://developer.android.com/jetpack/androidx/releases/security#1.0.0)
 > - `datastore` [1.0.0](https://developer.android.com/jetpack/androidx/releases/datastore#1.0.0)
-> - `tink` [1.7.0](https://github.com/google/tink/releases/tag/v1.7.0)
+> - `tink` [1.13.0](https://github.com/tink-crypto/tink-java/releases/tag/v1.13.0)
 
 ## Usage
 
@@ -190,7 +191,7 @@ val dataStore = DataStoreFactory.createEncrypted(
 [mavenCentral]: https://search.maven.org/artifact/io.github.osipxd/encrypted-datastore
 [license]: LICENSE
 
-[tink]: https://github.com/google/tink
+[tink]: https://github.com/tink-crypto/tink-java
 [secured-datastore]: https://github.com/Fi5t/secured-datastore
 [fi5t]: https://github.com/Fi5t
 [hack]: encrypted-datastore-preferences/src/main/java/io/github/osipxd/datastore/encrypted/PreferenceDataStoreHack.java

--- a/encrypted-datastore/src/main/kotlin/Aead.kt
+++ b/encrypted-datastore/src/main/kotlin/Aead.kt
@@ -5,7 +5,7 @@ import java.io.InputStream
 
 internal fun Aead.newDecryptedStream(inputStream: InputStream): InputStream {
     // Method 'decrypt' throws GeneralSecurityException for empty byte array,
-    // so let's check it is not empty.
+    // so check it is not empty.
     return if (inputStream.available() > 0) {
         decrypt(inputStream.readBytes(), null).inputStream()
     } else {

--- a/security-crypto-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStoreFactory.kt
+++ b/security-crypto-datastore-preferences/src/main/kotlin/EncryptedPreferenceDataStoreFactory.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.SupervisorJob
  * }
  * ```
  *
+ * @see encryptedPreferencesDataStore
  * @see PreferenceDataStoreFactory.create
  */
 public fun PreferenceDataStoreFactory.createEncrypted(

--- a/security-crypto-datastore-preferences/src/main/kotlin/EncryptedPreferencesDataStoreDelegate.kt
+++ b/security-crypto-datastore-preferences/src/main/kotlin/EncryptedPreferencesDataStoreDelegate.kt
@@ -1,0 +1,127 @@
+package io.github.osipxd.security.crypto
+
+import android.content.Context
+import androidx.annotation.GuardedBy
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.EncryptedFile.FileEncryptionScheme
+import androidx.security.crypto.MasterKeys
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Creates a property delegate for a single process DataStore with encryption. This should only
+ * be called once in a file (at the top level), and all usages of the DataStore should use
+ * a reference the same Instance. The receiver type for the property delegate must be an instance
+ * of [Context].
+ *
+ * This should only be used from a single application in a single classloader in a single process.
+ *
+ * Example usage:
+ * ```
+ * val Context.settingsDataStore by encryptedPreferencesDataStore(name = "settings")
+ *
+ * class SomeClass(val context: Context) {
+ *    suspend fun update() = context.settingsDataStore.edit {...}
+ * }
+ * ```
+ *
+ * @param name The name of the preferences. The preferences will be stored in a file in the
+ * "datastore/" subdirectory in the application context's files directory and is generated using
+ * [preferencesDataStoreFile].
+ * @param corruptionHandler The corruptionHandler is invoked if DataStore encounters a
+ * [androidx.datastore.core.CorruptionException] when attempting to read data. CorruptionExceptions
+ * are thrown by serializers when data can not be de-serialized.
+ * @param produceMigrations produce the migrations. The ApplicationContext is passed in to these
+ * callbacks as a parameter. DataMigrations are run before any access to data can occur. Each
+ * producer and migration may be run more than once whether or not it already succeeded
+ * (potentially because another migration failed or a write to disk failed.)
+ * @param scope The scope in which IO operations and transform functions will execute.
+ * @param masterKey The master key to use, defaults to `AES256-GCM` key with default alias
+ * [MasterKeys.MASTER_KEY_ALIAS].
+ * @param fileEncryptionScheme The [FileEncryptionScheme] to use, defaulting to
+ * [FileEncryptionScheme.AES256_GCM_HKDF_4KB].
+ * @param encryptionOptions Additional encryption options.
+ *
+ * @return a property delegate that manages a datastore as a singleton.
+ *
+ * @see PreferenceDataStoreFactory.createEncrypted
+ * @see EncryptedFile
+ */
+public fun encryptedPreferencesDataStore(
+    name: String,
+    corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
+    produceMigrations: (Context) -> List<DataMigration<Preferences>> = { emptyList() },
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    masterKey: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+    fileEncryptionScheme: FileEncryptionScheme = FileEncryptionScheme.AES256_GCM_HKDF_4KB,
+    encryptionOptions: EncryptedDataStoreOptions.() -> Unit = {},
+): ReadOnlyProperty<Context, DataStore<Preferences>> {
+    return EncryptedPreferenceDataStoreSingletonDelegate(
+        name = name,
+        corruptionHandler = corruptionHandler,
+        produceMigrations = produceMigrations,
+        scope = scope,
+        masterKey = masterKey,
+        fileEncryptionScheme = fileEncryptionScheme,
+        encryptionOptions = encryptionOptions,
+    )
+}
+
+/**
+ * Delegate class to manage Preferences DataStore as a singleton.
+ * Copied from [androidx.datastore.preferences.PreferenceDataStoreSingletonDelegate]
+ */
+internal class EncryptedPreferenceDataStoreSingletonDelegate internal constructor(
+    private val name: String,
+    private val corruptionHandler: ReplaceFileCorruptionHandler<Preferences>?,
+    private val produceMigrations: (Context) -> List<DataMigration<Preferences>>,
+    private val scope: CoroutineScope,
+    private val masterKey: String,
+    private val fileEncryptionScheme: FileEncryptionScheme,
+    private val encryptionOptions: EncryptedDataStoreOptions.() -> Unit
+) : ReadOnlyProperty<Context, DataStore<Preferences>> {
+
+    private val lock = Any()
+
+    @GuardedBy("lock")
+    @Volatile
+    private var INSTANCE: DataStore<Preferences>? = null
+
+    /**
+     * Gets the instance of the DataStore.
+     *
+     * @param thisRef must be an instance of [Context]
+     * @param property not used
+     */
+    override fun getValue(thisRef: Context, property: KProperty<*>): DataStore<Preferences> {
+        return INSTANCE ?: synchronized(lock) {
+            if (INSTANCE == null) {
+                val applicationContext = thisRef.applicationContext
+
+                INSTANCE = PreferenceDataStoreFactory.createEncrypted(
+                    corruptionHandler = corruptionHandler,
+                    migrations = produceMigrations(applicationContext),
+                    scope = scope,
+                    encryptionOptions = encryptionOptions,
+                ) {
+                    EncryptedFile.Builder(
+                        applicationContext.preferencesDataStoreFile(name),
+                        applicationContext,
+                        masterKey,
+                        fileEncryptionScheme,
+                    ).build()
+                }
+            }
+            INSTANCE!!
+        }
+    }
+}

--- a/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreDelegate.kt
+++ b/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreDelegate.kt
@@ -1,0 +1,134 @@
+package io.github.osipxd.security.crypto
+
+import android.content.Context
+import androidx.annotation.GuardedBy
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Serializer
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.dataStoreFile
+import androidx.security.crypto.EncryptedFile
+import androidx.security.crypto.EncryptedFile.FileEncryptionScheme
+import androidx.security.crypto.MasterKeys
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Creates a property delegate for a single process DataStore with encryption. This should only
+ * be called once in a file (at the top level), and all usages of the DataStore should use
+ * a reference the same Instance. The receiver type for the property delegate must be an instance
+ * of [Context].
+ *
+ * This should only be used from a single application in a single classloader in a single process.
+ *
+ * Example usage:
+ * ```
+ * val Context.settingsDataStore by encryptedDataStore(
+ *     fileName = "settings.pb",
+ *     serializer = SettingsSerializer,
+ * )
+ *
+ * class SomeClass(val context: Context) {
+ *    suspend fun update() = context.settingsDataStore.updateData {...}
+ * }
+ * ```
+ *
+ * @param fileName the filename relative to Context.applicationContext.filesDir that DataStore
+ * acts on. The File is obtained from [dataStoreFile]. It is created in the "/datastore"
+ * subdirectory.
+ * @param serializer The serializer for `T`.
+ * @param corruptionHandler The corruptionHandler is invoked if DataStore encounters a
+ * [androidx.datastore.core.CorruptionException] when attempting to read data. CorruptionExceptions
+ * are thrown by serializers when data can not be de-serialized.
+ * @param produceMigrations produce the migrations. The ApplicationContext is passed in to these
+ * callbacks as a parameter. DataMigrations are run before any access to data can occur. Each
+ * producer and migration may be run more than once whether or not it already succeeded
+ * (potentially because another migration failed or a write to disk failed.)
+ * @param scope The scope in which IO operations and transform functions will execute.
+ * @param masterKey The master key to use, defaults to `AES256-GCM` key with default alias
+ * [MasterKeys.MASTER_KEY_ALIAS].
+ * @param fileEncryptionScheme The [FileEncryptionScheme] to use, defaulting to
+ * [FileEncryptionScheme.AES256_GCM_HKDF_4KB].
+ * @param encryptionOptions Additional encryption options.
+ *
+ * @return a property delegate that manages a datastore as a singleton.
+ *
+ * @see DataStoreFactory.createEncrypted
+ * @see EncryptedFile
+ */
+public fun <T> encryptedDataStore(
+    fileName: String,
+    serializer: Serializer<T>,
+    corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
+    produceMigrations: (Context) -> List<DataMigration<T>> = { emptyList() },
+    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    masterKey: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+    fileEncryptionScheme: FileEncryptionScheme = FileEncryptionScheme.AES256_GCM_HKDF_4KB,
+    encryptionOptions: EncryptedDataStoreOptions.() -> Unit = {},
+): ReadOnlyProperty<Context, DataStore<T>> {
+    return EncryptedDataStoreSingletonDelegate(
+        fileName = fileName,
+        serializer = serializer,
+        corruptionHandler = corruptionHandler,
+        produceMigrations = produceMigrations,
+        scope = scope,
+        masterKey = masterKey,
+        fileEncryptionScheme = fileEncryptionScheme,
+        encryptionOptions = encryptionOptions,
+    )
+}
+
+/**
+ * Delegate class to manage DataStore as a singleton.
+ * Copied from [androidx.datastore.DataStoreSingletonDelegate]
+ */
+internal class EncryptedDataStoreSingletonDelegate<T> internal constructor(
+    private val fileName: String,
+    private val serializer: Serializer<T>,
+    private val corruptionHandler: ReplaceFileCorruptionHandler<T>?,
+    private val produceMigrations: (Context) -> List<DataMigration<T>>,
+    private val scope: CoroutineScope,
+    private val masterKey: String,
+    private val fileEncryptionScheme: FileEncryptionScheme,
+    private val encryptionOptions: EncryptedDataStoreOptions.() -> Unit
+) : ReadOnlyProperty<Context, DataStore<T>> {
+
+    private val lock = Any()
+
+    @GuardedBy("lock")
+    @Volatile
+    private var INSTANCE: DataStore<T>? = null
+
+    /**
+     * Gets the instance of the DataStore.
+     *
+     * @param thisRef must be an instance of [Context]
+     * @param property not used
+     */
+    override fun getValue(thisRef: Context, property: KProperty<*>): DataStore<T> {
+        return INSTANCE ?: synchronized(lock) {
+            if (INSTANCE == null) {
+                val applicationContext = thisRef.applicationContext
+                INSTANCE = DataStoreFactory.createEncrypted(
+                    corruptionHandler = corruptionHandler,
+                    serializer = serializer,
+                    migrations = produceMigrations(applicationContext),
+                    scope = scope,
+                    encryptionOptions = encryptionOptions,
+                ) {
+                    EncryptedFile.Builder(
+                        applicationContext.dataStoreFile(fileName),
+                        applicationContext,
+                        masterKey,
+                        fileEncryptionScheme,
+                    ).build()
+                }
+            }
+            INSTANCE!!
+        }
+    }
+}

--- a/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreFactory.kt
+++ b/security-crypto-datastore/src/main/kotlin/EncryptedDataStoreFactory.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.SupervisorJob
  * }
  * ```
  *
+ * @see encryptedDataStore
  * @see DataStoreFactory.create
  */
 public fun <T> DataStoreFactory.createEncrypted(


### PR DESCRIPTION
Delegates `encryptedDataStore` and `encryptedPreferencesDataStore` were added to simplify DataStore creation.
If you have the following code:

```kotlin
val dataStore = DataStoreFactory.createEncrypted(serializer) {
    EncryptedFile.Builder(
        context.dataStoreFile("filename"),
        context,
        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
        EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
    ).build()
}
```

You can simplify it using delegate for DataStore creation.

```kotlin
// 1. Move the field to top level of you Kotlin file and turn it to an extension on Context
// 2. Replace `DataStoreFactory.createEncrypted` with `encryptedDataStore`
val Context.dataStore by encryptedDataStore(
    fileName = "filename", // Keep file the same
    serializer = serializer,
)
```

> [!NOTE]
> This only will be interchangeable if you used `context.dataStoreFile(...)` to create datastore file.
> In case you have custom logic for master key creation, pass the created master key as a parameter `masterKey` to the delegate.

Closes #21 