### PR TITLE
v1.1.1 beta03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+*No changes*
+
+## [1.1.1-beta03] - 2024.05.13
+
 ### Added
 
 - Enforce version alignment between the library and DataStore using BOM (#45)
@@ -177,9 +181,10 @@ To continue use it, change the dependency module in your build script:
 - gradle-infrastructure `0.12.1` → `0.17`
 - Migrate dependencies to version catalogs
 
-[unreleased]: https://github.com/osipxd/encrypted-datastore/compare/1.1.1-beta02...main
-[1.1.1-beta02]: https://github.com/osipxd/encrypted-datastore/compare/v1.1.1-beta01...1.1.1-beta02
-[1.1.1-beta01]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0...1.1.1-beta01
+[unreleased]: https://github.com/osipxd/encrypted-datastore/compare/v1.1.1-beta03...main
+[1.1.1-beta03]: https://github.com/osipxd/encrypted-datastore/compare/v1.1.1-beta02...v1.1.1-beta03
+[1.1.1-beta02]: https://github.com/osipxd/encrypted-datastore/compare/v1.1.1-beta01...v1.1.1-beta02
+[1.1.1-beta01]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0...v1.1.1-beta01
 [1.0.0]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0-beta01...v1.0.0
 [1.0.0-beta01]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0-alpha04...v1.0.0-beta01
 [1.0.0-alpha04]: https://github.com/osipxd/encrypted-datastore/compare/v1.0.0-alpha03...v1.0.0-alpha04

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.github.osipxd:security-crypto-datastore:1.1.1-beta02")
+    implementation("io.github.osipxd:security-crypto-datastore:1.1.1-beta03")
     // Or, if you want to use Preferences DataStore:
-    implementation("io.github.osipxd:security-crypto-datastore-preferences:1.1.1-beta02")
+    implementation("io.github.osipxd:security-crypto-datastore-preferences:1.1.1-beta03")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 val datastoreVersion = libs.versions.datastore.get()
 allprojects {
     group = "io.github.osipxd"
-    version = "$datastoreVersion-beta02"
+    version = "$datastoreVersion-beta03"
 }
 
 redmadrobot {

--- a/buildSrc/src/main/kotlin/convention.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/convention.publish.gradle.kts
@@ -22,6 +22,9 @@ mavenPublishing {
     coordinates(artifactId = project.name)
 
     pom {
+        name = project.name
+        description = project.description
+
         setGitHubProject("osipxd/encrypted-datastore")
         licenses {
             mit()
@@ -38,4 +41,11 @@ plugins.withId("org.gradle.java-test-fixtures") {
     val feature = component.features.getByName(TestFixturesSupport.TEST_FIXTURES_FEATURE_NAME)
     component.withVariantsFromConfiguration(feature.apiElementsConfiguration) { skip() }
     component.withVariantsFromConfiguration(feature.runtimeElementsConfiguration) { skip() }
+
+    // Workaround to not publish test fixtures sources added by com.vanniktech.maven.publish plugin
+    // TODO: Remove as soon as https://github.com/vanniktech/gradle-maven-publish-plugin/issues/779 closed
+    afterEvaluate {
+        val configuration = project.configurations[feature.sourceSet.sourcesElementsConfigurationName]
+        component.withVariantsFromConfiguration(configuration) { skip() }
+    }
 }


### PR DESCRIPTION
### Added

- Enforce version alignment between the library and DataStore using BOM (#45)

### Housekeeping

- Publication migrated to [com.vanniktech:gradle-maven-publish-plugin](https://github.com/vanniktech/gradle-maven-publish-plugin)
